### PR TITLE
Supporting Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Options:
                                   running (sec)  [default: 3.0]
 ```
 
-
 ## Development
 
 Make sure you install [pre-commit](https://pre-commit.com/#install) and run:

--- a/README.md
+++ b/README.md
@@ -58,3 +58,22 @@ Options:
   --service-wait-time FLOAT       How long to wait for a service to be up an
                                   running (sec)  [default: 3.0]
 ```
+
+
+## Development
+
+Make sure you install [pre-commit](https://pre-commit.com/#install) and run:
+
+```shell
+pre-commit install
+```
+
+For testing you can use e.g.
+
+```shell
+poetry run multi-start \
+  --backend \
+  --backend-dir ../another-project/src \
+  --backend-cmd "poetry run invoke dev" \
+  --backend-port 8080
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "multi-start"
-version = "1.0.0"
+version = "1.0.1"
 description = "Run multiple services inside a docker container"
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/src/starter.py
+++ b/src/starter.py
@@ -202,4 +202,6 @@ class Runner:
             await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         finally:
             logger.info("Shutting down all processes")
-            await asyncio.gather(*[asyncio.create_task(stop_process(proc)) for proc in procs])
+            await asyncio.gather(
+                *[asyncio.create_task(stop_process(proc)) for proc in procs]
+            )

--- a/src/starter.py
+++ b/src/starter.py
@@ -196,9 +196,10 @@ class Runner:
         if nginx:
             procs.append(await start_service(nginx))
 
-        tasks = [p.wait() for p in procs]
-        tasks.append(self._stop.wait())
-        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-
-        logger.info("Shutting down all processes")
-        await asyncio.gather(*[stop_process(proc) for proc in procs])
+        try:
+            tasks = [asyncio.create_task(p.wait()) for p in procs]
+            tasks.append(asyncio.create_task(self._stop.wait()))
+            await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            logger.info("Shutting down all processes")
+            await asyncio.gather(*[asyncio.create_task(stop_process(proc)) for proc in procs])


### PR DESCRIPTION
Before patches crashes with something like:

```
Traceback (most recent call last):
  File "/usr/local/bin/multi-start", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/opt/pipx/venvs/multi-start/lib/python3.11/site-packages/src/cli.py", line 101, in main
    asyncio.run(
  File "/usr/lib/python3.11/asyncio/runners.py", line 188, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 120, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 650, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/pipx/venvs/multi-start/lib/python3.11/site-packages/src/starter.py", line 201, in start
    await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
  File "/usr/lib/python3.11/asyncio/tasks.py", line 420, in wait
    raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
TypeError: Passing coroutines is forbidden, use tasks explicitly.
sys:1: RuntimeWarning: coroutine 'Event.wait' was never awaited
sys:1: RuntimeWarning: coroutine 'Process.wait' was never awaited
```

After patch works fine. Not really sure why Python devs would prefer adding extra boilerplate, but it works with both old and new versions, supported in this form in 3.7+.